### PR TITLE
associations: Generate build_* for non-polymorphic belongs_to assoc

### DIFF
--- a/lib/rbs_activerecord/generator/associations.rb
+++ b/lib/rbs_activerecord/generator/associations.rb
@@ -68,7 +68,7 @@ module RbsActiverecord
           methods << "def #{assoc.name}: () -> #{is_optional ? optional : type}"
           methods << "def #{assoc.name}=: (#{optional}) -> #{optional}"
           methods << "def reload_#{assoc.name}: () -> #{optional}"
-          if assoc.polymorphic?
+          unless assoc.polymorphic?
             methods << "def build_#{assoc.name}: (untyped) -> #{type}"
             methods << "def create_#{assoc.name}: (untyped) -> #{type}"
             methods << "def create_#{assoc.name}!: (untyped) -> #{type}"

--- a/spec/rbs_activerecord/generator/associations_spec.rb
+++ b/spec/rbs_activerecord/generator/associations_spec.rb
@@ -108,6 +108,12 @@ RSpec.describe RbsActiverecord::Generator::Associations do
               def bar=: (Bar?) -> Bar?
 
               def reload_bar: () -> Bar?
+
+              def build_bar: (untyped) -> Bar
+
+              def create_bar: (untyped) -> Bar
+
+              def create_bar!: (untyped) -> Bar
             end
           RBS
         end
@@ -128,6 +134,12 @@ RSpec.describe RbsActiverecord::Generator::Associations do
               def bar=: (Bar?) -> Bar?
 
               def reload_bar: () -> Bar?
+
+              def build_bar: (untyped) -> Bar
+
+              def create_bar: (untyped) -> Bar
+
+              def create_bar!: (untyped) -> Bar
             end
           RBS
         end
@@ -148,12 +160,6 @@ RSpec.describe RbsActiverecord::Generator::Associations do
               def bar=: (untyped?) -> untyped?
 
               def reload_bar: () -> untyped?
-
-              def build_bar: (untyped) -> untyped
-
-              def create_bar: (untyped) -> untyped
-
-              def create_bar!: (untyped) -> untyped
             end
           RBS
         end

--- a/spec/rbs_activerecord/generator_spec.rb
+++ b/spec/rbs_activerecord/generator_spec.rb
@@ -149,12 +149,6 @@ RSpec.describe RbsActiverecord::Generator do
               def entryable=: (untyped?) -> untyped?
 
               def reload_entryable: () -> untyped?
-
-              def build_entryable: (untyped) -> untyped
-
-              def create_entryable: (untyped) -> untyped
-
-              def create_entryable!: (untyped) -> untyped
             end
 
             module GeneratedActiveStorageInstanceMethods


### PR DESCRIPTION
`#build_#{assoc}`, `#create_#{assoc}` and `#create_#{assoc}!` are defined only if the belongs_to association is *not* polymorphic. https://github.com/rails/rails/blob/v8.0.0/activerecord/lib/active_record/associations/builder/singular_association.rb#L16