### PR TITLE
association: Support changed?, previously_changed? and reset methods

### DIFF
--- a/lib/rbs_activerecord/generator/associations.rb
+++ b/lib/rbs_activerecord/generator/associations.rb
@@ -53,6 +53,9 @@ module RbsActiverecord
             def create_#{assoc.name}: (untyped) -> #{type}
             def create_#{assoc.name}!: (untyped) -> #{type}
             def reload_#{assoc.name}: () -> #{optional}
+            def reset_#{assoc.name}: () -> void
+            def #{assoc.name}_changed?: () -> bool
+            def #{assoc.name}_previously_changed?: () -> bool
           RBS
         end.join("\n")
       end
@@ -67,12 +70,13 @@ module RbsActiverecord
           methods = []
           methods << "def #{assoc.name}: () -> #{is_optional ? optional : type}"
           methods << "def #{assoc.name}=: (#{optional}) -> #{optional}"
-          methods << "def reload_#{assoc.name}: () -> #{optional}"
           unless assoc.polymorphic?
             methods << "def build_#{assoc.name}: (untyped) -> #{type}"
             methods << "def create_#{assoc.name}: (untyped) -> #{type}"
             methods << "def create_#{assoc.name}!: (untyped) -> #{type}"
           end
+          methods << "def reload_#{assoc.name}: () -> #{optional}"
+          methods << "def reset_#{assoc.name}: () -> void"
           methods.join("\n")
         end.join("\n")
       end

--- a/spec/rbs_activerecord/generator/associations_spec.rb
+++ b/spec/rbs_activerecord/generator/associations_spec.rb
@@ -80,6 +80,12 @@ RSpec.describe RbsActiverecord::Generator::Associations do
             def create_bar!: (untyped) -> Bar
 
             def reload_bar: () -> Bar?
+
+            def reset_bar: () -> void
+
+            def bar_changed?: () -> bool
+
+            def bar_previously_changed?: () -> bool
           end
         RBS
       end
@@ -107,13 +113,15 @@ RSpec.describe RbsActiverecord::Generator::Associations do
 
               def bar=: (Bar?) -> Bar?
 
-              def reload_bar: () -> Bar?
-
               def build_bar: (untyped) -> Bar
 
               def create_bar: (untyped) -> Bar
 
               def create_bar!: (untyped) -> Bar
+
+              def reload_bar: () -> Bar?
+
+              def reset_bar: () -> void
             end
           RBS
         end
@@ -133,13 +141,15 @@ RSpec.describe RbsActiverecord::Generator::Associations do
 
               def bar=: (Bar?) -> Bar?
 
-              def reload_bar: () -> Bar?
-
               def build_bar: (untyped) -> Bar
 
               def create_bar: (untyped) -> Bar
 
               def create_bar!: (untyped) -> Bar
+
+              def reload_bar: () -> Bar?
+
+              def reset_bar: () -> void
             end
           RBS
         end
@@ -160,6 +170,8 @@ RSpec.describe RbsActiverecord::Generator::Associations do
               def bar=: (untyped?) -> untyped?
 
               def reload_bar: () -> untyped?
+
+              def reset_bar: () -> void
             end
           RBS
         end

--- a/spec/rbs_activerecord/generator_spec.rb
+++ b/spec/rbs_activerecord/generator_spec.rb
@@ -132,6 +132,12 @@ RSpec.describe RbsActiverecord::Generator do
 
               def reload_avatar_attachment: () -> ActiveStorage::Attachment?
 
+              def reset_avatar_attachment: () -> void
+
+              def avatar_attachment_changed?: () -> bool
+
+              def avatar_attachment_previously_changed?: () -> bool
+
               def avatar_blob: () -> ActiveStorage::Blob?
 
               def avatar_blob=: (ActiveStorage::Blob?) -> ActiveStorage::Blob?
@@ -144,11 +150,19 @@ RSpec.describe RbsActiverecord::Generator do
 
               def reload_avatar_blob: () -> ActiveStorage::Blob?
 
+              def reset_avatar_blob: () -> void
+
+              def avatar_blob_changed?: () -> bool
+
+              def avatar_blob_previously_changed?: () -> bool
+
               def entryable: () -> untyped
 
               def entryable=: (untyped?) -> untyped?
 
               def reload_entryable: () -> untyped?
+
+              def reset_entryable: () -> void
             end
 
             module GeneratedActiveStorageInstanceMethods


### PR DESCRIPTION
Since v7.0, `#{association}_changed?` and
`#{association}_previously_changed?` methods were generated to the belongs_to associations.

In addition, since v7.1, `reset_#{association}` was also generated to both has_one and belongs_to associations.

refs:

* https://github.com/rails/rails/pull/42751
* https://github.com/rails/rails/pull/46165