### PR TITLE
enum: Override attribute accessor methods

### DIFF
--- a/lib/rbs_activerecord/generator/enum/instance_methods.rb
+++ b/lib/rbs_activerecord/generator/enum/instance_methods.rb
@@ -37,13 +37,19 @@ module RbsActiverecord
           return "" unless name
           return "" unless options.fetch(:instance_methods, true)
 
-          values.map do |value|
+          name_methods = <<~RBS
+            def #{name}: () -> String
+            def #{name}=: (String) -> String
+          RBS
+          value_methods = values.map do |value|
             method_name = enum_method_name(name, value, options)
             <<~RBS
               def #{method_name}!: () -> void
               def #{method_name}?: () -> bool
             RBS
           end.join("\n")
+
+          name_methods + value_methods
         end
       end
     end

--- a/spec/rbs_activerecord/generator/enum/instance_methods_spec.rb
+++ b/spec/rbs_activerecord/generator/enum/instance_methods_spec.rb
@@ -46,6 +46,10 @@ RSpec.describe RbsActiverecord::Generator::Enum::InstanceMethods do
         it "generates RBS" do
           expect(subject).to eq <<~RBS
             module GeneratedEnumInstanceMethods
+              def status: () -> String
+
+              def status=: (String) -> String
+
               def active!: () -> void
 
               def active?: () -> bool
@@ -88,6 +92,10 @@ RSpec.describe RbsActiverecord::Generator::Enum::InstanceMethods do
           it "generates RBS" do
             expect(subject).to eq <<~RBS
               module GeneratedEnumInstanceMethods
+                def status: () -> String
+
+                def status=: (String) -> String
+
                 def active!: () -> void
 
                 def active?: () -> bool
@@ -114,6 +122,10 @@ RSpec.describe RbsActiverecord::Generator::Enum::InstanceMethods do
           it "generates RBS" do
             expect(subject).to eq <<~RBS
               module GeneratedEnumInstanceMethods
+                def status: () -> String
+
+                def status=: (String) -> String
+
                 def status_active!: () -> void
 
                 def status_active?: () -> bool
@@ -138,6 +150,10 @@ RSpec.describe RbsActiverecord::Generator::Enum::InstanceMethods do
           it "generates RBS" do
             expect(subject).to eq <<~RBS
               module GeneratedEnumInstanceMethods
+                def status: () -> String
+
+                def status=: (String) -> String
+
                 def prefix_active!: () -> void
 
                 def prefix_active?: () -> bool
@@ -162,6 +178,10 @@ RSpec.describe RbsActiverecord::Generator::Enum::InstanceMethods do
           it "generates RBS" do
             expect(subject).to eq <<~RBS
               module GeneratedEnumInstanceMethods
+                def status: () -> String
+
+                def status=: (String) -> String
+
                 def prefix_active!: () -> void
 
                 def prefix_active?: () -> bool
@@ -188,6 +208,10 @@ RSpec.describe RbsActiverecord::Generator::Enum::InstanceMethods do
           it "generates RBS" do
             expect(subject).to eq <<~RBS
               module GeneratedEnumInstanceMethods
+                def status: () -> String
+
+                def status=: (String) -> String
+
                 def active_status!: () -> void
 
                 def active_status?: () -> bool
@@ -212,6 +236,10 @@ RSpec.describe RbsActiverecord::Generator::Enum::InstanceMethods do
           it "generates RBS" do
             expect(subject).to eq <<~RBS
               module GeneratedEnumInstanceMethods
+                def status: () -> String
+
+                def status=: (String) -> String
+
                 def active_suffix!: () -> void
 
                 def active_suffix?: () -> bool
@@ -236,6 +264,10 @@ RSpec.describe RbsActiverecord::Generator::Enum::InstanceMethods do
           it "generates RBS" do
             expect(subject).to eq <<~RBS
               module GeneratedEnumInstanceMethods
+                def status: () -> String
+
+                def status=: (String) -> String
+
                 def active_suffix!: () -> void
 
                 def active_suffix?: () -> bool
@@ -261,6 +293,10 @@ RSpec.describe RbsActiverecord::Generator::Enum::InstanceMethods do
         it "generates RBS" do
           expect(subject).to eq <<~RBS
             module GeneratedEnumInstanceMethods
+              def status: () -> String
+
+              def status=: (String) -> String
+
               def active!: () -> void
 
               def active?: () -> bool
@@ -285,6 +321,10 @@ RSpec.describe RbsActiverecord::Generator::Enum::InstanceMethods do
         it "generates RBS" do
           expect(subject).to eq <<~RBS
             module GeneratedEnumInstanceMethods
+              def timezone: () -> String
+
+              def timezone=: (String) -> String
+
               def America_Los_Angels!: () -> void
 
               def America_Los_Angels?: () -> bool

--- a/spec/rbs_activerecord/generator_spec.rb
+++ b/spec/rbs_activerecord/generator_spec.rb
@@ -224,6 +224,10 @@ RSpec.describe RbsActiverecord::Generator do
               def comments: () -> Relation
             end
             module GeneratedEnumInstanceMethods
+              def status: () -> String
+
+              def status=: (String) -> String
+
               def active!: () -> void
 
               def active?: () -> bool


### PR DESCRIPTION
ActiveRecord::Enum overrides the attribute methods for enum columns to return or to accept enum String value.  This generates the accessor methods for enum columns.

refs: https://api.rubyonrails.org/classes/ActiveRecord/Enum.html