### PR TITLE
Allow to change the accessor methods to pure methods

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,7 @@
         "kaminari",
         "mkpath",
         "modname",
+        "raketask",
         "requireds",
         "rmtree",
         "tasklib"

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ Run `rbs:activerecord:setup` task:
 Then rbs_activerecord will scan your code and generate RBS files into
 `sig/activerecord` directory.
 
+## Configurations
+
+You can change the behavior of the generator via rbs_activerecord.rake:
+
+* pure_accessors: Make accessor methods for columns pure.  It helps [Type narrowing](https://github.com/soutaro/steep/wiki/Release-Note-1.1#type-narrowing-on-method-calls-590).
+
 ## The goal of rbs_activerecord
 
 rbs_activerecord is an experimental project to enhance the type generation for ActiveRecord models.
@@ -43,6 +49,7 @@ Main differences between rbs_activerecord and rbs_rails are:
     * Support extension ActiveRecord from 3rd party gems ([#254](https://github.com/pocke/rbs_rails/pull/254))
         * ex. [kaminari-activerecord](https://github.com/ruby/gem_rbs_collection/pull/725)
     * Support composite primary keys ([#275](https://github.com/pocke/rbs_rails/pull/275))
+    * Support pure_accessors ([#302](https://github.com/pocke/rbs_rails/issues/302))
     * Extend return types of #pluck ([#273](https://github.com/pocke/rbs_rails/pull/273))
     * Override types of CollectionProxy ([#289](https://github.com/pocke/rbs_rails/pull/289))
 * Bug fixes

--- a/lib/generators/rbs_activerecord/install_generator.rb
+++ b/lib/generators/rbs_activerecord/install_generator.rb
@@ -11,7 +11,10 @@ module RbsActiverecord
         begin
           require "rbs_activerecord/rake_task"
 
-          RbsActiverecord::RakeTask.new
+          RbsActiverecord::RakeTask.new do |task|
+            # Make accessor methods for columns pure.
+            # task.pure_accessors = true
+          end
         rescue LoadError
           # failed to load rbs_activerecord. Skip to load rbs_activerecord tasks.
         end

--- a/lib/rbs_activerecord/generator.rb
+++ b/lib/rbs_activerecord/generator.rb
@@ -9,12 +9,15 @@ module RbsActiverecord
     attr_reader :klass #: singleton(ActiveRecord::Base)
     attr_reader :klass_name #: String
     attr_reader :model #: RbsActiverecord::Model
+    attr_reader :pure_accessors #: bool
 
     # @rbs klass: singleton(ActiveRecord::Base)
-    def initialize(klass) #: void
+    # @rbs pure_accessors: bool
+    def initialize(klass, pure_accessors: false) #: void
       @klass = klass
       @klass_name = klass.name || ""
       @model = Model.new(klass)
+      @pure_accessors = pure_accessors
     end
 
     def generate #: String  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
@@ -22,7 +25,7 @@ module RbsActiverecord
         # resolve-type-names: false
 
         #{header}
-          #{Attributes.new(model).generate}
+          #{Attributes.new(model, pure_accessors:).generate}
           #{Associations.new(model).generate}
 
           #{ActiveStorage::InstanceMethods.new(model).generate}

--- a/lib/rbs_activerecord/generator/attributes.rb
+++ b/lib/rbs_activerecord/generator/attributes.rb
@@ -6,10 +6,13 @@ module RbsActiverecord
       include Utils
 
       attr_reader :model #: RbsActiverecord::Model
+      attr_reader :pure_accessors #: bool
 
       # @rbs model: RbsActiverecord::Model
-      def initialize(model) #: void
+      # @rbs pure_accessors: bool
+      def initialize(model, pure_accessors:) #: void
         @model = model
+        @pure_accessors = pure_accessors
       end
 
       def generate #: String
@@ -30,6 +33,7 @@ module RbsActiverecord
         column_type = col.null ? optional : type
 
         <<~RBS
+          #{"%a{pure}" if pure_accessors}
           def #{col.name}: () -> #{column_type}
           def #{col.name}=: (#{column_type}) -> #{column_type}
           def #{col.name}?: () -> bool

--- a/lib/rbs_activerecord/rake_task.rb
+++ b/lib/rbs_activerecord/rake_task.rb
@@ -4,7 +4,9 @@ require "rake/tasklib"
 
 module RbsActiverecord
   class RakeTask < Rake::TaskLib
-    attr_accessor :name, :signature_root_dir
+    attr_accessor :name #: Symbol
+    attr_accessor :pure_accessors #: bool
+    attr_accessor :signature_root_dir #: Pathname
 
     # @rbs name: Symbol
     # @rbs &block: (RakeTask) -> void
@@ -12,6 +14,7 @@ module RbsActiverecord
       super()
 
       @name = name
+      @pure_accessors = false
       @signature_root_dir = Rails.root / "sig/activerecord"
 
       block&.call(self)
@@ -48,7 +51,7 @@ module RbsActiverecord
           next if klass.abstract_class?
           next unless klass.connection.table_exists?(klass.table_name)
 
-          rbs = Generator.new(klass).generate
+          rbs = Generator.new(klass, pure_accessors:).generate
 
           path = signature_root_dir / "app/models/#{klass.name.underscore}.rbs"
           path.dirname.mkpath

--- a/sig/rbs_activerecord/generator.rbs
+++ b/sig/rbs_activerecord/generator.rbs
@@ -10,8 +10,11 @@ module RbsActiverecord
 
     attr_reader model: RbsActiverecord::Model
 
+    attr_reader pure_accessors: bool
+
     # @rbs klass: singleton(ActiveRecord::Base)
-    def initialize: (singleton(ActiveRecord::Base) klass) -> void
+    # @rbs pure_accessors: bool
+    def initialize: (singleton(ActiveRecord::Base) klass, ?pure_accessors: bool) -> void
 
     def generate: () -> String
 

--- a/sig/rbs_activerecord/generator/attributes.rbs
+++ b/sig/rbs_activerecord/generator/attributes.rbs
@@ -7,8 +7,11 @@ module RbsActiverecord
 
       attr_reader model: RbsActiverecord::Model
 
+      attr_reader pure_accessors: bool
+
       # @rbs model: RbsActiverecord::Model
-      def initialize: (RbsActiverecord::Model model) -> void
+      # @rbs pure_accessors: bool
+      def initialize: (RbsActiverecord::Model model, pure_accessors: bool) -> void
 
       def generate: () -> String
 

--- a/sig/rbs_activerecord/rake_task.rbs
+++ b/sig/rbs_activerecord/rake_task.rbs
@@ -2,9 +2,11 @@
 
 module RbsActiverecord
   class RakeTask < Rake::TaskLib
-    attr_accessor name: untyped
+    attr_accessor name: Symbol
 
-    attr_accessor signature_root_dir: untyped
+    attr_accessor pure_accessors: bool
+
+    attr_accessor signature_root_dir: Pathname
 
     # @rbs name: Symbol
     # @rbs &block: (RakeTask) -> void

--- a/spec/rbs_activerecord/generator/attributes_spec.rb
+++ b/spec/rbs_activerecord/generator/attributes_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RbsActiverecord::Generator::Attributes do
   include RbsActiverecord::Utils
 
   describe "#generate" do
-    subject { format described_class.new(model).generate }
+    subject { format described_class.new(model, pure_accessors:).generate }
 
     before do
       stub_const "Foo", klass
@@ -18,284 +18,343 @@ RSpec.describe RbsActiverecord::Generator::Attributes do
     let(:model) { RbsActiverecord::Model.new(klass) }
     let(:klass) { Class.new(::ActiveRecord::Base) }
 
-    context "with a standard model" do
-      before do
-        ActiveRecord::Base.connection.create_table :foos, id: false do |t|
-          t.string :name
+    context "When pure_accessors is false" do
+      let(:pure_accessors) { false }
+
+      context "with a standard model" do
+        before do
+          ActiveRecord::Base.connection.create_table :foos, id: false do |t|
+            t.string :name
+          end
+        end
+
+        it "generates RBS" do
+          expect(subject).to eq(<<~RBS)
+            module GeneratedAttributeMethods
+              def name: () -> ::String?
+
+              def name=: (::String?) -> ::String?
+
+              def name?: () -> bool
+
+              def name_changed?: () -> bool
+
+              def name_change: () -> [ ::String?, ::String? ]
+
+              def name_will_change!: () -> void
+
+              def name_was: () -> ::String?
+
+              def name_previously_changed?: () -> bool
+
+              def name_previous_change: () -> ::Array[::String?]?
+
+              def name_previously_was: () -> ::String?
+
+              def name_before_last_save: () -> ::String?
+
+              def name_change_to_be_saved: () -> ::Array[::String?]?
+
+              def name_in_database: () -> ::String?
+
+              def saved_change_to_name: () -> ::Array[::String?]?
+
+              def saved_change_to_name?: () -> bool
+
+              def will_save_change_to_name?: () -> bool
+
+              def restore_name!: () -> void
+
+              def clear_name_change: () -> void
+            end
+          RBS
         end
       end
 
-      it "generates RBS" do
-        expect(subject).to eq(<<~RBS)
-          module GeneratedAttributeMethods
-            def name: () -> ::String?
-
-            def name=: (::String?) -> ::String?
-
-            def name?: () -> bool
-
-            def name_changed?: () -> bool
-
-            def name_change: () -> [ ::String?, ::String? ]
-
-            def name_will_change!: () -> void
-
-            def name_was: () -> ::String?
-
-            def name_previously_changed?: () -> bool
-
-            def name_previous_change: () -> ::Array[::String?]?
-
-            def name_previously_was: () -> ::String?
-
-            def name_before_last_save: () -> ::String?
-
-            def name_change_to_be_saved: () -> ::Array[::String?]?
-
-            def name_in_database: () -> ::String?
-
-            def saved_change_to_name: () -> ::Array[::String?]?
-
-            def saved_change_to_name?: () -> bool
-
-            def will_save_change_to_name?: () -> bool
-
-            def restore_name!: () -> void
-
-            def clear_name_change: () -> void
+      context "with a model having a non-nullable column" do
+        before do
+          ActiveRecord::Base.connection.create_table :foos, id: false do |t|
+            t.string :name, null: false
           end
-        RBS
+        end
+
+        it "generates RBS" do
+          expect(subject).to eq(<<~RBS)
+            module GeneratedAttributeMethods
+              def name: () -> ::String
+
+              def name=: (::String) -> ::String
+
+              def name?: () -> bool
+
+              def name_changed?: () -> bool
+
+              def name_change: () -> [ ::String?, ::String? ]
+
+              def name_will_change!: () -> void
+
+              def name_was: () -> ::String?
+
+              def name_previously_changed?: () -> bool
+
+              def name_previous_change: () -> ::Array[::String?]?
+
+              def name_previously_was: () -> ::String?
+
+              def name_before_last_save: () -> ::String?
+
+              def name_change_to_be_saved: () -> ::Array[::String?]?
+
+              def name_in_database: () -> ::String?
+
+              def saved_change_to_name: () -> ::Array[::String?]?
+
+              def saved_change_to_name?: () -> bool
+
+              def will_save_change_to_name?: () -> bool
+
+              def restore_name!: () -> void
+
+              def clear_name_change: () -> void
+            end
+          RBS
+        end
+      end
+
+      context "with a model having many kinds of columns" do
+        before do
+          ActiveRecord::Base.connection.create_table :foos, id: false do |t|
+            t.integer  :attr1
+            t.float    :attr2
+            t.decimal  :attr3
+            t.string   :attr4
+            t.text     :attr5
+            t.binary   :attr6
+            t.datetime :attr7
+            t.date     :attr8
+            t.time     :attr9
+            t.boolean  :attr10
+          end
+        end
+
+        it "generates RBS" do
+          expect(subject).to include("def attr1: () -> ::Integer?")
+          expect(subject).to include("def attr2: () -> ::Float?")
+          expect(subject).to include("def attr3: () -> ::BigDecimal?")
+          expect(subject).to include("def attr4: () -> ::String?")
+          expect(subject).to include("def attr5: () -> ::String?")
+          expect(subject).to include("def attr6: () -> ::String?")
+          expect(subject).to include("def attr7: () -> ::ActiveSupport::TimeWithZone?")
+          expect(subject).to include("def attr8: () -> ::Date?")
+          expect(subject).to include("def attr9: () -> ::Time?")
+          expect(subject).to include("def attr10: () -> bool")
+        end
+      end
+
+      context "with a model having attributes via ActiveRecord::Attributes " do
+        before do
+          ActiveRecord::Base.connection.create_table :foos do |t|
+          end
+
+          klass.instance_eval do
+            attribute :name, :string
+            attribute :age, :integer
+          end
+        end
+
+        it "generates RBS" do
+          expect(subject).to eq(<<~RBS)
+            module GeneratedAttributeMethods
+              def id: () -> ::Integer
+
+              def id=: (::Integer) -> ::Integer
+
+              def id?: () -> bool
+
+              def id_changed?: () -> bool
+
+              def id_change: () -> [ ::Integer?, ::Integer? ]
+
+              def id_will_change!: () -> void
+
+              def id_was: () -> ::Integer?
+
+              def id_previously_changed?: () -> bool
+
+              def id_previous_change: () -> ::Array[::Integer?]?
+
+              def id_previously_was: () -> ::Integer?
+
+              def id_before_last_save: () -> ::Integer?
+
+              def id_change_to_be_saved: () -> ::Array[::Integer?]?
+
+              def id_in_database: () -> ::Integer?
+
+              def saved_change_to_id: () -> ::Array[::Integer?]?
+
+              def saved_change_to_id?: () -> bool
+
+              def will_save_change_to_id?: () -> bool
+
+              def restore_id!: () -> void
+
+              def clear_id_change: () -> void
+
+              def name: () -> ::String
+
+              def name=: (::String) -> ::String
+
+              def age: () -> ::Integer
+
+              def age=: (::Integer) -> ::Integer
+            end
+          RBS
+        end
+      end
+
+      context "with a model having aliases" do
+        before do
+          ActiveRecord::Base.connection.create_table :foos do |t|
+          end
+
+          klass.instance_eval do
+            alias_attribute :new_id, :id
+          end
+        end
+
+        it "generates RBS" do
+          expect(subject).to eq(<<~RBS)
+            module GeneratedAttributeMethods
+              def id: () -> ::Integer
+
+              def id=: (::Integer) -> ::Integer
+
+              def id?: () -> bool
+
+              def id_changed?: () -> bool
+
+              def id_change: () -> [ ::Integer?, ::Integer? ]
+
+              def id_will_change!: () -> void
+
+              def id_was: () -> ::Integer?
+
+              def id_previously_changed?: () -> bool
+
+              def id_previous_change: () -> ::Array[::Integer?]?
+
+              def id_previously_was: () -> ::Integer?
+
+              def id_before_last_save: () -> ::Integer?
+
+              def id_change_to_be_saved: () -> ::Array[::Integer?]?
+
+              def id_in_database: () -> ::Integer?
+
+              def saved_change_to_id: () -> ::Array[::Integer?]?
+
+              def saved_change_to_id?: () -> bool
+
+              def will_save_change_to_id?: () -> bool
+
+              def restore_id!: () -> void
+
+              def clear_id_change: () -> void
+
+              alias new_id id
+
+              alias new_id= id=
+
+              alias new_id? id?
+
+              alias new_id_changed? id_changed?
+
+              alias new_id_change id_change
+
+              alias new_id_will_change! id_will_change!
+
+              alias new_id_was id_was
+
+              alias new_id_previously_changed? id_previously_changed?
+
+              alias new_id_previous_change id_previous_change
+
+              alias new_id_previously_was id_previously_was
+
+              alias new_id_before_last_save id_before_last_save
+
+              alias new_id_change_to_be_saved id_change_to_be_saved
+
+              alias new_id_in_database id_in_database
+
+              alias saved_change_to_new_id saved_change_to_id
+
+              alias saved_change_to_new_id? saved_change_to_id?
+
+              alias will_save_change_to_new_id? will_save_change_to_id?
+
+              alias restore_new_id! restore_id!
+
+              alias clear_new_id_change clear_id_change
+            end
+          RBS
+        end
       end
     end
 
-    context "with a model having a non-nullable column" do
-      before do
-        ActiveRecord::Base.connection.create_table :foos, id: false do |t|
-          t.string :name, null: false
-        end
-      end
+    context "When pure_accessors is true" do
+      let(:pure_accessors) { true }
 
-      it "generates RBS" do
-        expect(subject).to eq(<<~RBS)
-          module GeneratedAttributeMethods
-            def name: () -> ::String
-
-            def name=: (::String) -> ::String
-
-            def name?: () -> bool
-
-            def name_changed?: () -> bool
-
-            def name_change: () -> [ ::String?, ::String? ]
-
-            def name_will_change!: () -> void
-
-            def name_was: () -> ::String?
-
-            def name_previously_changed?: () -> bool
-
-            def name_previous_change: () -> ::Array[::String?]?
-
-            def name_previously_was: () -> ::String?
-
-            def name_before_last_save: () -> ::String?
-
-            def name_change_to_be_saved: () -> ::Array[::String?]?
-
-            def name_in_database: () -> ::String?
-
-            def saved_change_to_name: () -> ::Array[::String?]?
-
-            def saved_change_to_name?: () -> bool
-
-            def will_save_change_to_name?: () -> bool
-
-            def restore_name!: () -> void
-
-            def clear_name_change: () -> void
+      context "with a standard model" do
+        before do
+          ActiveRecord::Base.connection.create_table :foos, id: false do |t|
+            t.string :name
           end
-        RBS
-      end
-    end
-
-    context "with a model having many kinds of columns" do
-      before do
-        ActiveRecord::Base.connection.create_table :foos, id: false do |t|
-          t.integer  :attr1
-          t.float    :attr2
-          t.decimal  :attr3
-          t.string   :attr4
-          t.text     :attr5
-          t.binary   :attr6
-          t.datetime :attr7
-          t.date     :attr8
-          t.time     :attr9
-          t.boolean  :attr10
-        end
-      end
-
-      it "generates RBS" do
-        expect(subject).to include("def attr1: () -> ::Integer?")
-        expect(subject).to include("def attr2: () -> ::Float?")
-        expect(subject).to include("def attr3: () -> ::BigDecimal?")
-        expect(subject).to include("def attr4: () -> ::String?")
-        expect(subject).to include("def attr5: () -> ::String?")
-        expect(subject).to include("def attr6: () -> ::String?")
-        expect(subject).to include("def attr7: () -> ::ActiveSupport::TimeWithZone?")
-        expect(subject).to include("def attr8: () -> ::Date?")
-        expect(subject).to include("def attr9: () -> ::Time?")
-        expect(subject).to include("def attr10: () -> bool")
-      end
-    end
-
-    context "with a model having attributes via ActiveRecord::Attributes " do
-      before do
-        ActiveRecord::Base.connection.create_table :foos do |t|
         end
 
-        klass.instance_eval do
-          attribute :name, :string
-          attribute :age, :integer
+        it "generates RBS" do
+          expect(subject).to eq(<<~RBS)
+            module GeneratedAttributeMethods
+              %a{pure}
+              def name: () -> ::String?
+
+              def name=: (::String?) -> ::String?
+
+              def name?: () -> bool
+
+              def name_changed?: () -> bool
+
+              def name_change: () -> [ ::String?, ::String? ]
+
+              def name_will_change!: () -> void
+
+              def name_was: () -> ::String?
+
+              def name_previously_changed?: () -> bool
+
+              def name_previous_change: () -> ::Array[::String?]?
+
+              def name_previously_was: () -> ::String?
+
+              def name_before_last_save: () -> ::String?
+
+              def name_change_to_be_saved: () -> ::Array[::String?]?
+
+              def name_in_database: () -> ::String?
+
+              def saved_change_to_name: () -> ::Array[::String?]?
+
+              def saved_change_to_name?: () -> bool
+
+              def will_save_change_to_name?: () -> bool
+
+              def restore_name!: () -> void
+
+              def clear_name_change: () -> void
+            end
+          RBS
         end
-      end
-
-      it "generates RBS" do
-        expect(subject).to eq(<<~RBS)
-          module GeneratedAttributeMethods
-            def id: () -> ::Integer
-
-            def id=: (::Integer) -> ::Integer
-
-            def id?: () -> bool
-
-            def id_changed?: () -> bool
-
-            def id_change: () -> [ ::Integer?, ::Integer? ]
-
-            def id_will_change!: () -> void
-
-            def id_was: () -> ::Integer?
-
-            def id_previously_changed?: () -> bool
-
-            def id_previous_change: () -> ::Array[::Integer?]?
-
-            def id_previously_was: () -> ::Integer?
-
-            def id_before_last_save: () -> ::Integer?
-
-            def id_change_to_be_saved: () -> ::Array[::Integer?]?
-
-            def id_in_database: () -> ::Integer?
-
-            def saved_change_to_id: () -> ::Array[::Integer?]?
-
-            def saved_change_to_id?: () -> bool
-
-            def will_save_change_to_id?: () -> bool
-
-            def restore_id!: () -> void
-
-            def clear_id_change: () -> void
-
-            def name: () -> ::String
-
-            def name=: (::String) -> ::String
-
-            def age: () -> ::Integer
-
-            def age=: (::Integer) -> ::Integer
-          end
-        RBS
-      end
-    end
-
-    context "with a model having aliases" do
-      before do
-        ActiveRecord::Base.connection.create_table :foos do |t|
-        end
-
-        klass.instance_eval do
-          alias_attribute :new_id, :id
-        end
-      end
-
-      it "generates RBS" do
-        expect(subject).to eq(<<~RBS)
-          module GeneratedAttributeMethods
-            def id: () -> ::Integer
-
-            def id=: (::Integer) -> ::Integer
-
-            def id?: () -> bool
-
-            def id_changed?: () -> bool
-
-            def id_change: () -> [ ::Integer?, ::Integer? ]
-
-            def id_will_change!: () -> void
-
-            def id_was: () -> ::Integer?
-
-            def id_previously_changed?: () -> bool
-
-            def id_previous_change: () -> ::Array[::Integer?]?
-
-            def id_previously_was: () -> ::Integer?
-
-            def id_before_last_save: () -> ::Integer?
-
-            def id_change_to_be_saved: () -> ::Array[::Integer?]?
-
-            def id_in_database: () -> ::Integer?
-
-            def saved_change_to_id: () -> ::Array[::Integer?]?
-
-            def saved_change_to_id?: () -> bool
-
-            def will_save_change_to_id?: () -> bool
-
-            def restore_id!: () -> void
-
-            def clear_id_change: () -> void
-
-            alias new_id id
-
-            alias new_id= id=
-
-            alias new_id? id?
-
-            alias new_id_changed? id_changed?
-
-            alias new_id_change id_change
-
-            alias new_id_will_change! id_will_change!
-
-            alias new_id_was id_was
-
-            alias new_id_previously_changed? id_previously_changed?
-
-            alias new_id_previous_change id_previous_change
-
-            alias new_id_previously_was id_previously_was
-
-            alias new_id_before_last_save id_before_last_save
-
-            alias new_id_change_to_be_saved id_change_to_be_saved
-
-            alias new_id_in_database id_in_database
-
-            alias saved_change_to_new_id saved_change_to_id
-
-            alias saved_change_to_new_id? saved_change_to_id?
-
-            alias will_save_change_to_new_id? will_save_change_to_id?
-
-            alias restore_new_id! restore_id!
-
-            alias clear_new_id_change clear_id_change
-          end
-        RBS
       end
     end
   end


### PR DESCRIPTION
To narrow the type of the attribute of models, this allows to change the accessor methods to pure methods.