### PR TITLE
deps: Drop Ruby 3.1 support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.2
 
 Layout/LeadingCommentSpace:
   AllowRBSInlineAnnotation: true

--- a/rbs_activerecord.gemspec
+++ b/rbs_activerecord.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = "A RBS files generator for activerecord gem"
   spec.homepage = "https://github.com/tk0miya/rbs_activerecord"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.1.0"
+  spec.required_ruby_version = ">= 3.2.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage


### PR DESCRIPTION
Ruby 3.1 becomes EOL on 2025-03-26.