### PR TITLE
Add actionlint workflow for GitHub Actions linting

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,19 @@
+name: actionlint
+
+on:
+  push:
+    branches:
+      - main
+
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - name: Run actionlint
+      shell: bash
+      run: |
+        bash <(curl -L https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+        ./actionlint -color


### PR DESCRIPTION
## Summary
This PR adds a new GitHub Actions workflow that automatically lints workflow files using actionlint on every push to main and on pull requests.

## Changes
- Added `.github/workflows/actionlint.yml` workflow file that:
  - Runs on pushes to the main branch and all pull requests
  - Downloads and executes actionlint to validate GitHub Actions workflow syntax and best practices
  - Provides colored output for better readability of linting results

## Details
The workflow uses actionlint's official download script to ensure the latest version is used, then runs the linter with color output enabled. This helps catch workflow configuration issues early and maintains consistency across all GitHub Actions workflows in the repository.

https://claude.ai/code/session_01AS4h5NaTXgw9fUUm1sW7ht