### PR TITLE
Update Ruby version configurations in CI workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ jobs:
         ruby:
           - '3.3'
           - '3.4'
+          - '4.0'
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/rbs_collection.yml
+++ b/.github/workflows/rbs_collection.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.3
+        ruby-version: ruby
         bundler-cache: true
     - name: Update rbs collection
       run: bundle exec rbs collection update

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.3
+          ruby-version: ruby
           bundler-cache: true
       - name: Publish to RubyGems
         uses: rubygems/release-gem@v1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,9 +67,9 @@ GEM
     drb (2.2.3)
     erb (5.1.3)
     erubi (1.13.1)
-    ffi (1.17.1)
-    ffi (1.17.1-x86_64-darwin)
-    ffi (1.17.1-x86_64-linux-gnu)
+    ffi (1.17.4)
+    ffi (1.17.4-x86_64-darwin)
+    ffi (1.17.4-x86_64-linux-gnu)
     fileutils (1.7.3)
     globalid (1.3.0)
       activesupport (>= 6.1)
@@ -256,4 +256,4 @@ DEPENDENCIES
   steep
 
 BUNDLED WITH
-   2.5.18
+  4.0.9


### PR DESCRIPTION
## Summary
This PR updates the Ruby version configurations across multiple GitHub Actions workflows to support newer Ruby versions and use more flexible version specifications.

## Key Changes
- **rbs_collection.yml**: Changed `ruby-version` from `3.3` to `ruby` to use the default/latest Ruby version
- **release.yml**: Changed `ruby-version` from `3.3` to `ruby` to use the default/latest Ruby version
- **main.yml**: Added Ruby `4.0` to the test matrix alongside existing `3.3` and `3.4` versions

## Details
The changes to use `ruby-version: ruby` in the setup-ruby action allow these workflows to automatically use the default Ruby version specified in the repository's `.ruby-version` file or the latest stable version, providing more flexibility and reducing the need to manually update version numbers in workflow files.

The addition of Ruby 4.0 to the main test matrix ensures the codebase is tested against the latest Ruby version, helping to identify compatibility issues early.

https://claude.ai/code/session_018KSCNfqGKxzGaWVWr2LFxk