### PR TITLE
Introduce rubocop-numbered-params

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@ AllCops:
   TargetRubyVersion: 3.2
 
 plugins:
+  - rubocop-numbered-params
   - rubocop-rake
   - rubocop-rbs_inline
   - rubocop-rspec

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gemspec
 gem "rake", "~> 13.4"
 
 gem "rubocop", "~> 1.88"
+gem "rubocop-numbered-params"
 gem "rubocop-rake"
 gem "rubocop-rbs_inline"
 gem "rubocop-rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,6 +185,9 @@ GEM
     rubocop-ast (1.49.1)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
+    rubocop-numbered-params (1.0.0)
+      lint_roller (~> 1.0)
+      rubocop (>= 1.72.1)
     rubocop-rake (0.7.1)
       lint_roller (~> 1.1)
       rubocop (>= 1.72.1)
@@ -254,6 +257,7 @@ DEPENDENCIES
   rspec
   rspec-mocks
   rubocop (~> 1.88)
+  rubocop-numbered-params
   rubocop-rake
   rubocop-rbs_inline
   rubocop-rspec

--- a/lib/rbs_activerecord/generator/associations.rb
+++ b/lib/rbs_activerecord/generator/associations.rb
@@ -85,7 +85,7 @@ module RbsActiverecord
       def polymorphic_owner_types(assoc) #: String  # rubocop:disable Metrics/AbcSize
         table_name = model.klass.name.to_s.tableize.to_sym
         owners = ActiveRecord::Base.descendants.select do |klass|
-          klass.reflect_on_all_associations.any? { |a| a.name == table_name && a.options[:as] == assoc.name }
+          klass.reflect_on_all_associations.any? { _1.name == table_name && _1.options[:as] == assoc.name }
         end
 
         if owners.empty?

--- a/lib/rbs_activerecord/generator/attributes.rb
+++ b/lib/rbs_activerecord/generator/attributes.rb
@@ -18,7 +18,7 @@ module RbsActiverecord
       def generate #: String
         <<~RBS
           module GeneratedAttributeMethods
-            #{model.columns.map { |c| column(c) }.join("\n")}
+            #{model.columns.map { column(_1) }.join("\n")}
             #{attributes.map { |name, type| attribute(name, type) }.join("\n")}
             #{model.attribute_aliases.map { |from, to| alias_method(from, to) }.join("\n")}
           end
@@ -58,7 +58,7 @@ module RbsActiverecord
 
       def attributes #: Hash[String, untyped]
         model.attribute_types.filter_map do |name, type|
-          [name, type] if model.columns.none? { |col| col.name == name }
+          [name, type] if model.columns.none? { _1.name == name }
         end.to_h
       end
 

--- a/lib/rbs_activerecord/generator/delegated_type/instance_methods.rb
+++ b/lib/rbs_activerecord/generator/delegated_type/instance_methods.rb
@@ -19,7 +19,7 @@ module RbsActiverecord
         def generate #: String
           <<~RBS.strip
             module GeneratedDelegatedTypeInstanceMethods
-              #{delegated_types.map { |node| delegated_type(node) }.join("\n")}
+              #{delegated_types.map { delegated_type(_1) }.join("\n")}
             end
           RBS
         end
@@ -27,18 +27,18 @@ module RbsActiverecord
         private
 
         def delegated_types #: Array[Prism::CallNode]
-          declarations.select { |node| node.name == :delegated_type }
+          declarations.select { _1.name == :delegated_type }
         end
 
         # @rbs node: Prism::CallNode
-        def delegated_type(node) #: String  # rubocop:disable Metrics/AbcSize
+        def delegated_type(node) #: String
           arguments = node.arguments&.arguments || []
-          name, options = arguments.map { |arg| Parser.eval_node(arg) } #: [String?, Hash[Symbol, untyped]]
+          name, options = arguments.map { Parser.eval_node(_1) } #: [String?, Hash[Symbol, untyped]]
           return "" unless name
 
           types = options[:types]
           role_methods = <<~RBS
-            def #{name}_class: () -> (#{types.map { |type| "::#{type}" }.join(" | ")})
+            def #{name}_class: () -> (#{types.map { "::#{_1}" }.join(" | ")})
             def #{name}_name: () -> ::String
           RBS
 

--- a/lib/rbs_activerecord/generator/delegated_type/scopes.rb
+++ b/lib/rbs_activerecord/generator/delegated_type/scopes.rb
@@ -17,7 +17,7 @@ module RbsActiverecord
         def generate #: String
           <<~RBS.strip
             module GeneratedDelegatedTypeScopeMethods[Relation]
-              #{delegated_types.map { |node| delegated_type(node) }.join("\n")}
+              #{delegated_types.map { delegated_type(_1) }.join("\n")}
             end
           RBS
         end
@@ -25,13 +25,13 @@ module RbsActiverecord
         private
 
         def delegated_types #: Array[Prism::CallNode]
-          declarations.select { |node| node.name == :delegated_type }
+          declarations.select { _1.name == :delegated_type }
         end
 
         # @rbs node: Prism::CallNode
         def delegated_type(node) #: String
           arguments = node.arguments&.arguments || []
-          name, options = arguments.map { |arg| Parser.eval_node(arg) } #: [String?, Hash[Symbol, untyped]]
+          name, options = arguments.map { Parser.eval_node(_1) } #: [String?, Hash[Symbol, untyped]]
           return "" unless name
 
           options[:types].map do |type|

--- a/lib/rbs_activerecord/generator/enum/base.rb
+++ b/lib/rbs_activerecord/generator/enum/base.rb
@@ -7,9 +7,9 @@ module RbsActiverecord
         private
 
         # @rbs node: Prism::CallNode
-        def parse_arguments(node) #: [String?, Array[String | Symbol], Hash[Symbol, untyped]] # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
+        def parse_arguments(node) #: [String?, Array[String | Symbol], Hash[Symbol, untyped]] # rubocop:disable Metrics/CyclomaticComplexity
           arguments = node.arguments&.arguments || []
-          args = arguments.map { |arg| Parser.eval_node(arg) }
+          args = arguments.map { Parser.eval_node(_1) }
           return nil, [], {} if args.empty?
 
           name = args[0] #: String?

--- a/lib/rbs_activerecord/generator/enum/instance_methods.rb
+++ b/lib/rbs_activerecord/generator/enum/instance_methods.rb
@@ -21,7 +21,7 @@ module RbsActiverecord
         def generate #: String
           <<~RBS.strip
             module GeneratedEnumInstanceMethods
-              #{enums.map { |node| enum(node) }.join("\n")}
+              #{enums.map { enum(_1) }.join("\n")}
             end
           RBS
         end
@@ -29,7 +29,7 @@ module RbsActiverecord
         private
 
         def enums #: Array[Prism::CallNode]
-          declarations.select { |node| node.name == :enum }
+          declarations.select { _1.name == :enum }
         end
 
         # @rbs node: Prism::CallNode
@@ -58,7 +58,7 @@ module RbsActiverecord
 
         # @rbs name: String
         def column_type(name) #: String
-          col = model.columns.find { |c| c.name == name.to_s }
+          col = model.columns.find { _1.name == name.to_s }
           if col
             sql_type_to_class(col.type)
           else

--- a/lib/rbs_activerecord/generator/enum/mappings.rb
+++ b/lib/rbs_activerecord/generator/enum/mappings.rb
@@ -19,7 +19,7 @@ module RbsActiverecord
         def generate #: String
           <<~RBS.strip
             module GeneratedEnumMappingMethods
-              #{enums.map { |node| enum(node) }.join("\n")}
+              #{enums.map { enum(_1) }.join("\n")}
             end
           RBS
         end
@@ -27,7 +27,7 @@ module RbsActiverecord
         private
 
         def enums #: Array[Prism::CallNode]
-          declarations.select { |node| node.name == :enum }
+          declarations.select { _1.name == :enum }
         end
 
         # @rbs node: Prism::CallNode

--- a/lib/rbs_activerecord/generator/enum/scopes.rb
+++ b/lib/rbs_activerecord/generator/enum/scopes.rb
@@ -19,7 +19,7 @@ module RbsActiverecord
         def generate #: String
           <<~RBS.strip
             module GeneratedEnumScopeMethods[Relation]
-              #{enums.map { |node| enum(node) }.join("\n")}
+              #{enums.map { enum(_1) }.join("\n")}
             end
           RBS
         end
@@ -27,7 +27,7 @@ module RbsActiverecord
         private
 
         def enums #: Array[Prism::CallNode]
-          declarations.select { |node| node.name == :enum }
+          declarations.select { _1.name == :enum }
         end
 
         # @rbs node: Prism::CallNode

--- a/lib/rbs_activerecord/generator/scopes.rb
+++ b/lib/rbs_activerecord/generator/scopes.rb
@@ -16,7 +16,7 @@ module RbsActiverecord
       def generate #: String
         <<~RBS.strip
           module GeneratedScopeMethods[Relation]
-            #{scopes.map { |node| scope(node) }.join("\n")}
+            #{scopes.map { scope(_1) }.join("\n")}
           end
         RBS
       end
@@ -24,7 +24,7 @@ module RbsActiverecord
       private
 
       def scopes #: Array[Prism::CallNode]
-        declarations.select { |node| node.name == :scope }
+        declarations.select { _1.name == :scope }
       end
 
       # @rbs node: Prism::CallNode

--- a/lib/rbs_activerecord/model.rb
+++ b/lib/rbs_activerecord/model.rb
@@ -28,7 +28,7 @@ module RbsActiverecord
 
     def parents #: Array[singleton(ActiveRecord::Base)]
       ancestors = klass.ancestors #: Array[singleton(ActiveRecord::Base)]
-      ancestors.select { |cls| cls < ActiveRecord::Base && cls != klass && !cls.abstract_class? }
+      ancestors.select { _1 < ActiveRecord::Base && _1 != klass && !_1.abstract_class? }
     end
   end
 end

--- a/lib/rbs_activerecord/parser.rb
+++ b/lib/rbs_activerecord/parser.rb
@@ -16,7 +16,7 @@ module RbsActiverecord
 
     # @rbs filename: String
     def parse_file(filename) #: Hash[String, Array[Prism::CallNode]]
-      File.open(filename) { |f| parse(f.read) }
+      File.open(filename) { parse(_1.read) }
     end
     module_function :parse_file
 

--- a/lib/rbs_activerecord/parser/evaluator.rb
+++ b/lib/rbs_activerecord/parser/evaluator.rb
@@ -19,7 +19,7 @@ module RbsActiverecord
         when Prism::StringNode
           node.unescaped
         when Prism::ArrayNode
-          node.elements.map { |e| eval_node(e) }
+          node.elements.map { eval_node(_1) }
         when Prism::HashNode, Prism::KeywordHashNode
           node.elements.filter_map do |assoc|
             case assoc

--- a/lib/rbs_activerecord/parser/include_expander.rb
+++ b/lib/rbs_activerecord/parser/include_expander.rb
@@ -22,7 +22,7 @@ module RbsActiverecord
       def expand #: void
         declarations.each_value do |decls|
           loop do
-            index = decls.index { |node| node.name == :include }
+            index = decls.index { _1.name == :include }
             break unless index
 
             included_module = decls.delete_at(index) || raise
@@ -39,7 +39,7 @@ module RbsActiverecord
       # @rbs node: Prism::CallNode
       def included_blocks_for(node) #: Array[Prism::CallNode]
         modules = node.arguments&.arguments.to_a
-                      .map { |arg| Parser.eval_node(arg) }
+                      .map { Parser.eval_node(_1) }
                       .grep(String)
         modules.flat_map do |modname|
           mod = const_get(modname)

--- a/lib/rbs_activerecord/parser/include_expander/module.rb
+++ b/lib/rbs_activerecord/parser/include_expander/module.rb
@@ -21,7 +21,7 @@ module RbsActiverecord
         def included_blocks #: Array[Prism::CallNode]
           return [] unless concern?
 
-          declarations.select { |node| node.name == :included }
+          declarations.select { _1.name == :included }
         end
 
         private

--- a/lib/rbs_activerecord/parser/visitor.rb
+++ b/lib/rbs_activerecord/parser/visitor.rb
@@ -14,7 +14,7 @@ module RbsActiverecord
       end
 
       def current_namespace #: String
-        context.map { |node| Parser.eval_node(node.constant_path) }.join("::")
+        context.map { Parser.eval_node(_1.constant_path) }.join("::")
       end
 
       # @rbs override

--- a/lib/rbs_activerecord/utils.rb
+++ b/lib/rbs_activerecord/utils.rb
@@ -31,11 +31,11 @@ module RbsActiverecord
       when Array
         primary_keys = klass.primary_key.map(&:to_s)
         types = klass.columns
-                     .select { |column| primary_keys.include?(column.name) }
-                     .map { |pk| sql_type_to_class(pk.type) }
+                     .select { primary_keys.include?(_1.name) }
+                     .map { sql_type_to_class(_1.type) }
         "[#{types.join(" | ")}]"
       else
-        primary_key = klass.columns.find { |column| column.name == klass.primary_key }
+        primary_key = klass.columns.find { _1.name == klass.primary_key }
         sql_type_to_class(primary_key.type)
       end
     end

--- a/rbs_activerecord.gemspec
+++ b/rbs_activerecord.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
     end
   end
   spec.bindir = "exe"
-  spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
+  spec.executables = spec.files.grep(%r{\Aexe/}) { File.basename(_1) }
   spec.require_paths = ["lib"]
 
   spec.add_dependency "activerecord"


### PR DESCRIPTION
Add the `rubocop-numbered-params` plugin to enforce a consistent style for numbered block parameters, matching the setup already used in other repositories.

- Add `rubocop-numbered-params` to the Gemfile and Gemfile.lock
- Register the plugin in `.rubocop.yml`
- Autocorrect existing offenses (converting single-line block arguments to numbered parameters, and dropping the now-redundant `Metrics/AbcSize` disable directives)

🤖 Generated with [Claude Code](https://claude.com/claude-code)