### PR TITLE
Align .rubocop.yml with shared skeleton baseline

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
+# NOTE: Rules are sorted in ASCII order.
+
 AllCops:
   NewCops: enable
   TargetRubyVersion: 3.2
@@ -8,19 +10,37 @@ plugins:
   - rubocop-rbs_inline
   - rubocop-rspec
 
+# Layout
 Layout/LeadingCommentSpace:
   AllowRBSInlineAnnotation: true
   AllowSteepAnnotation: true
+
+Layout/LineLength:
+  Max: 120
+
+# Metrics
+Metrics/AbcSize:
+  Max: 20
 
 Metrics/BlockLength:
   Exclude:
     - "spec/**/*.rb"
 
+Metrics/ClassLength:
+  Max: 200
+
 Metrics/MethodLength:
   Max: 30
 
+# RSpec
 RSpec/ExampleLength:
-  Max: 20
+  Enabled: false
+
+RSpec/MultipleMemoizedHelpers:
+  Max: 10
+
+RSpec/MultipleExpectations:
+  Enabled: false
 
 RSpec/NamedSubject:
   Enabled: false
@@ -28,15 +48,7 @@ RSpec/NamedSubject:
 RSpec/NestedGroups:
   Max: 5
 
-RSpec/MultipleExpectations:
-  Enabled: false
-
-RSpec/MultipleMemoizedHelpers:
-  Max: 10
-
-Style/Documentation:
-  Enabled: false
-
+# RbsInline
 Style/RbsInline/MissingTypeAnnotation:
   EnforcedStyle: doc_style_and_return_annotation
   Exclude:
@@ -47,6 +59,19 @@ Style/RbsInline/RedundantTypeAnnotation:
 
 Style/RbsInline/RequireRbsInlineComment:
   EnforcedStyle: never
+
+# Style
+Style/AccessorGrouping:
+  Enabled: false
+
+Style/CommentedKeyword:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/HashSyntax:
+  EnforcedShorthandSyntax: always
 
 Style/RedundantFormat:
   Enabled: false

--- a/lib/rbs_activerecord/generator.rb
+++ b/lib/rbs_activerecord/generator.rb
@@ -3,7 +3,7 @@
 require "rails"
 
 module RbsActiverecord
-  class Generator # rubocop:disable Metrics/ClassLength
+  class Generator
     include Utils
 
     attr_reader :klass #: singleton(ActiveRecord::Base)

--- a/lib/rbs_activerecord/utils.rb
+++ b/lib/rbs_activerecord/utils.rb
@@ -8,7 +8,7 @@ module RbsActiverecord
     def format(str) #: String
       parsed = RBS::Parser.parse_signature(str)
       StringIO.new.tap do |out|
-        RBS::Writer.new(out: out).write(parsed[1] + parsed[2])
+        RBS::Writer.new(out:).write(parsed[1] + parsed[2])
       end.string
     end
 
@@ -26,7 +26,7 @@ module RbsActiverecord
     end
 
     # @rbs klass: singleton(ActiveRecord::Base)
-    def primary_key_type_for(klass) #: String  # rubocop:disable Metrics/AbcSize
+    def primary_key_type_for(klass) #: String
       case klass.primary_key
       when Array
         primary_keys = klass.primary_key.map(&:to_s)

--- a/spec/rbs_activerecord/generator/attributes_spec.rb
+++ b/spec/rbs_activerecord/generator/attributes_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe RbsActiverecord::Generator::Attributes do
           end
         end
 
-        it "generates RBS" do # rubocop:disable RSpec/ExampleLength
+        it "generates RBS" do
           expect(subject).to eq(<<~RBS)
             module GeneratedAttributeMethods
               def name: () -> ::String?
@@ -78,7 +78,7 @@ RSpec.describe RbsActiverecord::Generator::Attributes do
           end
         end
 
-        it "generates RBS" do # rubocop:disable RSpec/ExampleLength
+        it "generates RBS" do
           expect(subject).to eq(<<~RBS)
             module GeneratedAttributeMethods
               def name: () -> ::String
@@ -161,7 +161,7 @@ RSpec.describe RbsActiverecord::Generator::Attributes do
           end
         end
 
-        it "generates RBS" do # rubocop:disable RSpec/ExampleLength
+        it "generates RBS" do
           expect(subject).to eq(<<~RBS)
             module GeneratedAttributeMethods
               def id: () -> ::Integer
@@ -221,7 +221,7 @@ RSpec.describe RbsActiverecord::Generator::Attributes do
           end
         end
 
-        it "generates RBS" do # rubocop:disable RSpec/ExampleLength
+        it "generates RBS" do
           expect(subject).to eq(<<~RBS)
             module GeneratedAttributeMethods
               def id: () -> ::Integer
@@ -311,7 +311,7 @@ RSpec.describe RbsActiverecord::Generator::Attributes do
           end
         end
 
-        it "generates RBS" do # rubocop:disable RSpec/ExampleLength
+        it "generates RBS" do
           expect(subject).to eq(<<~RBS)
             module GeneratedAttributeMethods
               %a{pure}

--- a/spec/rbs_activerecord/generator_spec.rb
+++ b/spec/rbs_activerecord/generator_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe RbsActiverecord::Generator do
       let(:klass) { Foo } # see ../fixtures/app/models/foo.rb
       let(:pure_accessors) { false }
 
-      it "generates RBS" do # rubocop:disable RSpec/ExampleLength
+      it "generates RBS" do
         expect(subject).to eq <<~RBS
           # resolve-type-names: false
 


### PR DESCRIPTION
## Summary

Align this repository's `.rubocop.yml` with the shared `init-ruby-project`
skeleton so linting rules are consistent across all Ruby repositories, and
fix the offenses the aligned config surfaces.

## Config changes

- Fill in missing cops: `Layout/LineLength`, `Metrics/AbcSize`,
  `Metrics/ClassLength`, `Style/AccessorGrouping`, `Style/CommentedKeyword`,
  `Style/HashSyntax`
- `RSpec/ExampleLength`: drop `Max: 20` and disable it to match the baseline
- Rules sorted in ASCII order to match the skeleton

The existing `Style/RedundantFormat` disable and project-specific
extensions (`Metrics/BlockLength` exclude, RbsInline excludes) are preserved.

## Code changes (offenses surfaced by the new cops)

- `utils.rb`: use `out:` shorthand (`Style/HashSyntax`)
- Remove now-redundant inline `rubocop:disable` directives that the baseline
  values (`Metrics/ClassLength`, `Metrics/AbcSize`, `RSpec/ExampleLength`)
  already cover

Verified locally with `rubocop` (no offenses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)